### PR TITLE
Change Repository URL for Updating

### DIFF
--- a/source/fbi/update.c
+++ b/source/fbi/update.c
@@ -18,7 +18,7 @@ static void update_check_update(ui_view* view, void* data, float* progress, char
     Result res = 0;
 
     json_t* json = NULL;
-    if(R_SUCCEEDED(res = http_download_json("https://api.github.com/repos/Steveice10/FBI/releases/latest", &json, 16 * 1024))) {
+    if(R_SUCCEEDED(res = http_download_json("https://api.github.com/repos/nh-server/FBI-NH/releases/latest", &json, 16 * 1024))) {
         if(json_is_object(json)) {
             json_t* name = json_object_get(json, "name");
             json_t* assets = json_object_get(json, "assets");


### PR DESCRIPTION
Change the URL of the repository to match the fork, so updating FBI actually works.

I know there likely won't be many, if any, updates in the future, but it'd be nice if everything functioned.